### PR TITLE
Inherit environment variables when launching the process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ ignore = [
     "S604",    # shell injection (we control the inputs)
     "PLR2004", # magic values (syscall numbers are naturally magic)
     "T201",    # print statements (used for debugging)
+    "TD002",   # missing author in TODO
+    "TD003",   # missing issue link in TODO
+    "FIX002",  # line contains TODO
 ]
 
 [tool.ruff.lint.pylint]

--- a/strace_macos/tracer.py
+++ b/strace_macos/tracer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import signal
 import sys
 import time
@@ -230,6 +231,10 @@ class Tracer:
             # Launch process
             launch_info = self.lldb.SBLaunchInfo(command[1:] if len(command) > 1 else [])
             launch_info.SetWorkingDirectory(str(Path.cwd()))
+            launch_info.SetEnvironmentEntries(
+                [f"{k}={v}" for k, v in os.environ.items()], append=True
+            )
+            # TODO: stdout and stderr are being hidden?
 
             error = self.lldb.SBError()
             process = target.Launch(launch_info, error)


### PR DESCRIPTION
Previously, none of the variables would be inherited, changing the behavior of the program.

Fixes #48