### PR TITLE
Fix stdout/stderr being hidden when tracing processes

### DIFF
--- a/strace_macos/tracer.py
+++ b/strace_macos/tracer.py
@@ -234,7 +234,20 @@ class Tracer:
             launch_info.SetEnvironmentEntries(
                 [f"{k}={v}" for k, v in os.environ.items()], append=True
             )
-            # TODO: stdout and stderr are being hidden?
+            # Redirect stdout/stderr to parent process's stdout/stderr so traced
+            # process output is visible (LLDB defaults to a pseudo-terminal)
+            launch_info.AddOpenFileAction(
+                1,
+                "/dev/stdout",
+                False,  # noqa: FBT003 - LLDB API (read)
+                True,  # noqa: FBT003 - LLDB API (write)
+            )  # stdout
+            launch_info.AddOpenFileAction(
+                2,
+                "/dev/stderr",
+                False,  # noqa: FBT003 - LLDB API (read)
+                True,  # noqa: FBT003 - LLDB API (write)
+            )  # stderr
 
             error = self.lldb.SBError()
             process = target.Launch(launch_info, error)

--- a/tests/fixtures/mode_misc.h
+++ b/tests/fixtures/mode_misc.h
@@ -45,6 +45,17 @@ int mode_fail(int argc, char *argv[]) {
   return 1;
 }
 
+int mode_stdio_test(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  /* Write unique markers to both stdout and stderr */
+  fprintf(stdout, "STDOUT_MARKER_12345\n");
+  fflush(stdout);
+  fprintf(stderr, "STDERR_MARKER_67890\n");
+  fflush(stderr);
+  return 0;
+}
+
 int mode_default(int argc, char *argv[]) {
   /* Print all arguments */
   for (int i = 0; i < argc; i++) {

--- a/tests/fixtures/modes.h
+++ b/tests/fixtures/modes.h
@@ -33,6 +33,7 @@ int mode_fork_exec(int argc, char *argv[]);
 int mode_sysinfo(int argc, char *argv[]);
 int mode_long_running(int argc, char *argv[]);
 int mode_fail(int argc, char *argv[]);
+int mode_stdio_test(int argc, char *argv[]);
 int mode_default(int argc, char *argv[]);
 
 /* Global mode registry */
@@ -69,6 +70,7 @@ static const test_mode_t modes[] = {
     {"--long-running", mode_long_running,
      "Long-running process for attach testing"},
     {"--fail", mode_fail, "Exit with non-zero status"},
+    {"--stdio-test", mode_stdio_test, "Print markers to stdout and stderr"},
     {NULL, mode_default, "Default mode: print args"},
 };
 


### PR DESCRIPTION

LLDB by default redirects stdout/stderr to a pseudo-terminal, making
the traced process output invisible. Fix this by explicitly redirecting
stdout and stderr to /dev/stdout and /dev/stderr using AddOpenFileAction.

Add regression test and --stdio-test mode to verify the fix.

Closes: #48


