### PR TITLE
Improve decoding support for get/settimeofday()

### DIFF
--- a/strace_macos/syscalls/definitions/__init__.py
+++ b/strace_macos/syscalls/definitions/__init__.py
@@ -432,17 +432,32 @@ class StructParamBase(Param):
     # Subclasses must set this in __init__
     direction: ParamDirection
 
+    def should_decode(self, ctx: DecodeContext): # FIXME: return type annotation
+        """Should we run decoding right now? 
+        That is, check param direction, and determine if the data to decode is
+        there now.
+
+        Returns:
+            If not, returns False and the appropriate return value for the caller.
+            If yes, returns True (and None)
+        """
+        if ctx.at_entry and self.direction != ParamDirection.IN:
+            return False, PointerArg(ctx.raw_value)  # Return as pointer for now
+        if not ctx.at_entry and self.direction != ParamDirection.OUT:
+            return False, None  # Already decoded at entry
+        return True, None
+
     def decode(self, ctx: DecodeContext) -> SyscallArg | None:
         """Decode struct pointer to StructArg.
 
         This handles direction filtering and delegates to decode_struct()
         for the actual struct decoding logic.
         """
+
         # Direction filtering: only decode at appropriate time
-        if ctx.at_entry and self.direction != ParamDirection.IN:
-            return PointerArg(ctx.raw_value)  # Return as pointer for now
-        if not ctx.at_entry and self.direction != ParamDirection.OUT:
-            return None  # Already decoded at entry
+        sd, ret = self.should_decode(ctx)
+        if not sd:
+            return ret
 
         # Skip NULL pointers
         if ctx.raw_value == 0:

--- a/strace_macos/syscalls/definitions/__init__.py
+++ b/strace_macos/syscalls/definitions/__init__.py
@@ -501,6 +501,10 @@ class StructParamBase(Param):
         if error.Fail() or not data:
             return None
 
+        return self.parse_struct(data, no_abbrev)
+
+    def parse_struct(self, data, no_abbrev:bool):
+
         # Parse struct using ctypes
         try:
             struct_obj = self.struct_type.from_buffer_copy(data)

--- a/strace_macos/syscalls/definitions/ipc.py
+++ b/strace_macos/syscalls/definitions/ipc.py
@@ -71,7 +71,7 @@ IPC_SYSCALLS: list[SyscallDef] = [
             FdSetParam(),  # readfds
             FdSetParam(),  # writefds
             FdSetParam(),  # exceptfds
-            TimespecParam(),  # timeout
+            TimespecParam(direction=ParamDirection.IN),  # timeout
             PointerParam(),  # sigmask - TODO: decode sigset_t
         ],
     ),  # 312
@@ -237,7 +237,7 @@ IPC_SYSCALLS: list[SyscallDef] = [
             IntParam(),  # nchanges
             KeventParam(count_arg_index=4, direction=ParamDirection.OUT),  # eventlist
             IntParam(),  # nevents
-            TimespecParam(),  # timeout
+            TimespecParam(direction=ParamDirection.IN),  # timeout
         ],
     ),  # 363
     SyscallDef(
@@ -250,7 +250,7 @@ IPC_SYSCALLS: list[SyscallDef] = [
             Kevent64Param(count_arg_index=4, direction=ParamDirection.OUT),  # eventlist
             IntParam(),  # nevents
             UnsignedParam(),  # flags
-            TimespecParam(),  # timeout
+            TimespecParam(direction=ParamDirection.IN),  # timeout
         ],
     ),  # 369
     SyscallDef(

--- a/strace_macos/syscalls/definitions/ipc.py
+++ b/strace_macos/syscalls/definitions/ipc.py
@@ -51,7 +51,7 @@ IPC_SYSCALLS: list[SyscallDef] = [
             FdSetParam(),  # readfds
             FdSetParam(),  # writefds
             FdSetParam(),  # exceptfds
-            TimevalParam(),  # timeout
+            TimevalParam(direction = ParamDirection.IN),  # timeout
         ],
     ),  # 93
     SyscallDef(

--- a/strace_macos/syscalls/definitions/time.py
+++ b/strace_macos/syscalls/definitions/time.py
@@ -19,6 +19,7 @@ from strace_macos.syscalls.struct_params import (
     TimespecParam,
     TimevalParam,
     TimezoneParam,
+    TimevalArray2Param,
 )
 from strace_macos.syscalls.symbols.time import ITIMER_CONSTANTS
 
@@ -60,12 +61,12 @@ TIME_SYSCALLS: list[SyscallDef] = [
     SyscallDef(
         numbers.SYS_utimes,
         "utimes",
-        params=[StringParam(), PointerParam()],
+        params=[StringParam(), TimevalArray2Param(direction=ParamDirection.IN)],
     ),  # 138
     SyscallDef(
         numbers.SYS_futimes,
         "futimes",
-        params=[FileDescriptorParam(), PointerParam()],
+        params=[FileDescriptorParam(), TimevalArray2Param(direction=ParamDirection.IN)],
     ),  # 139
     SyscallDef(
         numbers.SYS_adjtime,

--- a/strace_macos/syscalls/definitions/time.py
+++ b/strace_macos/syscalls/definitions/time.py
@@ -16,6 +16,7 @@ from strace_macos.syscalls.definitions import (
     SyscallDef,
 )
 from strace_macos.syscalls.struct_params import (
+    ITimerValParam,
     TimespecParam,
     TimevalParam,
     TimezoneParam,
@@ -30,8 +31,8 @@ TIME_SYSCALLS: list[SyscallDef] = [
         "setitimer",
         params=[
             ConstParam(ITIMER_CONSTANTS),
-            PointerParam(),
-            PointerParam(),
+            ITimerValParam(direction=ParamDirection.IN),
+            ITimerValParam(direction=ParamDirection.OUT),
         ],
     ),  # 83
     SyscallDef(
@@ -39,7 +40,7 @@ TIME_SYSCALLS: list[SyscallDef] = [
         "getitimer",
         params=[
             ConstParam(ITIMER_CONSTANTS),
-            PointerParam(),
+            ITimerValParam(direction=ParamDirection.OUT),
         ],
     ),  # 86
     SyscallDef(

--- a/strace_macos/syscalls/definitions/time.py
+++ b/strace_macos/syscalls/definitions/time.py
@@ -9,9 +9,14 @@ from strace_macos.syscalls import numbers
 from strace_macos.syscalls.definitions import (
     ConstParam,
     IntParam,
+    ParamDirection,
     PointerParam,
     StringParam,
     SyscallDef,
+)
+from strace_macos.syscalls.struct_params import (
+    TimespecParam,
+    TimezoneParam,
 )
 from strace_macos.syscalls.symbols.time import ITIMER_CONSTANTS
 
@@ -37,12 +42,18 @@ TIME_SYSCALLS: list[SyscallDef] = [
     SyscallDef(
         numbers.SYS_gettimeofday,
         "gettimeofday",
-        params=[PointerParam(), PointerParam()],
+        params=[
+            TimespecParam(direction=ParamDirection.OUT),
+            TimezoneParam(direction=ParamDirection.OUT),
+        ],
     ),  # 116
     SyscallDef(
         numbers.SYS_settimeofday,
         "settimeofday",
-        params=[PointerParam(), PointerParam()],
+        params=[
+            TimespecParam(direction=ParamDirection.IN),
+            TimezoneParam(direction=ParamDirection.IN),
+        ],
     ),  # 122
     SyscallDef(
         numbers.SYS_utimes,

--- a/strace_macos/syscalls/definitions/time.py
+++ b/strace_macos/syscalls/definitions/time.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from strace_macos.syscalls import numbers
 from strace_macos.syscalls.definitions import (
     ConstParam,
+    FileDescriptorParam,
     IntParam,
     ParamDirection,
     PointerParam,
@@ -16,6 +17,7 @@ from strace_macos.syscalls.definitions import (
 )
 from strace_macos.syscalls.struct_params import (
     TimespecParam,
+    TimevalParam,
     TimezoneParam,
 )
 from strace_macos.syscalls.symbols.time import ITIMER_CONSTANTS
@@ -63,11 +65,14 @@ TIME_SYSCALLS: list[SyscallDef] = [
     SyscallDef(
         numbers.SYS_futimes,
         "futimes",
-        params=[IntParam(), PointerParam()],
+        params=[FileDescriptorParam(), PointerParam()],
     ),  # 139
     SyscallDef(
         numbers.SYS_adjtime,
         "adjtime",
-        params=[PointerParam(), PointerParam()],
+        params=[
+            TimevalParam(direction=ParamDirection.IN),
+            TimevalParam(direction=ParamDirection.OUT),
+        ]
     ),  # 140
 ]

--- a/strace_macos/syscalls/struct_params/__init__.py
+++ b/strace_macos/syscalls/struct_params/__init__.py
@@ -36,6 +36,7 @@ from strace_macos.syscalls.struct_params.stat import StatParam
 from strace_macos.syscalls.struct_params.statfs import StatfsParam
 from strace_macos.syscalls.struct_params.termios import TermiosParam
 from strace_macos.syscalls.struct_params.time_structs import (
+    ITimerValParam,
     TimespecParam,
     TimevalParam,
     TimezoneParam,
@@ -52,6 +53,7 @@ __all__ = [
     "FssearchblockParam",
     "IntArrayParam",
     "IntPtrParam",
+    "ITimerValParam",
     "IovecParam",
     "Kevent64Param",
     "KeventParam",

--- a/strace_macos/syscalls/struct_params/__init__.py
+++ b/strace_macos/syscalls/struct_params/__init__.py
@@ -14,8 +14,6 @@ from strace_macos.syscalls.struct_params.event_structs import (
     Kevent64Param,
     KeventParam,
     PollfdParam,
-    TimespecParam,
-    TimevalParam,
 )
 from strace_macos.syscalls.struct_params.fssearchblock import FssearchblockParam
 from strace_macos.syscalls.struct_params.int_ptr import FdPairParam, IntArrayParam, IntPtrParam
@@ -37,6 +35,11 @@ from strace_macos.syscalls.struct_params.sockaddr import SockaddrParam
 from strace_macos.syscalls.struct_params.stat import StatParam
 from strace_macos.syscalls.struct_params.statfs import StatfsParam
 from strace_macos.syscalls.struct_params.termios import TermiosParam
+from strace_macos.syscalls.struct_params.time_structs import (
+    TimespecParam,
+    TimevalParam,
+    TimezoneParam,
+)
 from strace_macos.syscalls.struct_params.winsize import WinsizeParam
 
 __all__ = [
@@ -67,5 +70,6 @@ __all__ = [
     "TermiosParam",
     "TimespecParam",
     "TimevalParam",
+    "TimezoneParam",
     "WinsizeParam",
 ]

--- a/strace_macos/syscalls/struct_params/__init__.py
+++ b/strace_macos/syscalls/struct_params/__init__.py
@@ -39,6 +39,7 @@ from strace_macos.syscalls.struct_params.time_structs import (
     TimespecParam,
     TimevalParam,
     TimezoneParam,
+    TimevalArray2Param,
 )
 from strace_macos.syscalls.struct_params.winsize import WinsizeParam
 
@@ -71,5 +72,6 @@ __all__ = [
     "TimespecParam",
     "TimevalParam",
     "TimezoneParam",
+    "TimevalArray2Param",
     "WinsizeParam",
 ]

--- a/strace_macos/syscalls/struct_params/decode_array.py
+++ b/strace_macos/syscalls/struct_params/decode_array.py
@@ -1,0 +1,37 @@
+
+from strace_macos.lldb_loader import load_lldb_module
+
+def decode_array(
+    self,
+    process: Any,
+    address: int,
+    count: int,
+    struct_type: type # FIXME
+) -> list[dict[str, str | int]] | None:
+    """Decode an array of structures."""
+
+    lldb = load_lldb_module()
+    error = lldb.SBError()
+    size = ctypes.sizeof(struct_type)
+    total_size = size * count
+
+    data = process.ReadMemory(address, total_size, error)
+    if error.Fail() or not data:
+        return None
+
+    struct_list = []
+    for i in range(count):
+        offset = i * size
+        try:
+            pfd = struct_type.from_buffer_copy(data[offset : offset + size])
+        except (ValueError, TypeError):
+            continue
+
+        struct_list.append(
+            {
+                "fd": pfd.fd,
+                "events": self._decode_events(pfd.events),
+            }
+        )
+
+    return struct_list if struct_list else None

--- a/strace_macos/syscalls/struct_params/decode_array.py
+++ b/strace_macos/syscalls/struct_params/decode_array.py
@@ -7,11 +7,10 @@ from strace_macos.lldb_loader import load_lldb_module
 
 from strace_macos.syscalls.args import StructArg
 
-def _generic_decode(ctx, param, struct):
+def _generic_decode(ctx, param, data):
     # Decode the struct using the scalar param 
-    decoded_fields = param.decode_struct(
-            ctx.process, ctx.raw_value, no_abbrev=ctx.tracer.no_abbrev
-    )
+    decoded_fields = param.parse_struct(data, no_abbrev=ctx.tracer.no_abbrev)
+
     if decoded_fields:
         return StructArg(decoded_fields)
     return None
@@ -58,8 +57,7 @@ def decode_array(
         except (ValueError, TypeError):
             continue
 
-        struct_list.append(
-            decode_fn(ctx, param, struct)
-        )
+        s = decode_fn(ctx, param, struct)
+        struct_list.append(s)
 
     return struct_list if struct_list else None

--- a/strace_macos/syscalls/struct_params/decode_array.py
+++ b/strace_macos/syscalls/struct_params/decode_array.py
@@ -1,21 +1,52 @@
 
+from __future__ import annotations
+
+import ctypes
+
 from strace_macos.lldb_loader import load_lldb_module
 
+from strace_macos.syscalls.args import StructArg
+
+def _generic_decode(ctx, param, struct):
+    # Decode the struct using the scalar param 
+    decoded_fields = param.decode_struct(
+            ctx.process, ctx.raw_value, no_abbrev=ctx.tracer.no_abbrev
+    )
+    if decoded_fields:
+        return StructArg(decoded_fields)
+    return None
+
+#def _generic_decode(ctx, struct):
+#    out = dict()
+#    for field in struct._fields_:
+#        field_name = field[0]
+#        field_value = getattr(struct, field[0])
+#        out[field_name] = field_value
+#
+#    # FIXME: what to do here if no fields?
+#    return out
+
 def decode_array(
-    self,
-    process: Any,
+    ctx: DecodeContext,
     address: int,
     count: int,
-    struct_type: type # FIXME
+    param: StructParamBase,
+    decode_fn: callable = _generic_decode, # FIXME - better annotation
 ) -> list[dict[str, str | int]] | None:
     """Decode an array of structures."""
 
+    # is now the right time to decode (ie check param direction)
+    sd, _ = param.should_decode(ctx=ctx)
+    if not sd:
+        return None
+
     lldb = load_lldb_module()
     error = lldb.SBError()
+    struct_type = param.struct_type
     size = ctypes.sizeof(struct_type)
     total_size = size * count
 
-    data = process.ReadMemory(address, total_size, error)
+    data = ctx.process.ReadMemory(address, total_size, error)
     if error.Fail() or not data:
         return None
 
@@ -23,15 +54,12 @@ def decode_array(
     for i in range(count):
         offset = i * size
         try:
-            pfd = struct_type.from_buffer_copy(data[offset : offset + size])
+            struct = struct_type.from_buffer_copy(data[offset : offset + size])
         except (ValueError, TypeError):
             continue
 
         struct_list.append(
-            {
-                "fd": pfd.fd,
-                "events": self._decode_events(pfd.events),
-            }
+            decode_fn(ctx, param, struct)
         )
 
     return struct_list if struct_list else None

--- a/strace_macos/syscalls/struct_params/decode_array.py
+++ b/strace_macos/syscalls/struct_params/decode_array.py
@@ -15,16 +15,6 @@ def _generic_decode(ctx, param, data):
         return StructArg(decoded_fields)
     return None
 
-#def _generic_decode(ctx, struct):
-#    out = dict()
-#    for field in struct._fields_:
-#        field_name = field[0]
-#        field_value = getattr(struct, field[0])
-#        out[field_name] = field_value
-#
-#    # FIXME: what to do here if no fields?
-#    return out
-
 def decode_array(
     ctx: DecodeContext,
     address: int,

--- a/strace_macos/syscalls/struct_params/event_structs.py
+++ b/strace_macos/syscalls/struct_params/event_structs.py
@@ -436,60 +436,6 @@ class PollfdParam(Param):
         return "|".join(flags) if flags else f"0x{value:x}"
 
 
-class TimespecStruct(ctypes.Structure):
-    """ctypes definition for struct timespec.
-
-    struct timespec {
-        time_t  tv_sec;   // seconds
-        long    tv_nsec;  // nanoseconds
-    };
-    """
-
-    _fields_: ClassVar[list[tuple[str, type]]] = [
-        ("tv_sec", ctypes.c_int64),  # time_t
-        ("tv_nsec", ctypes.c_long),  # long
-    ]
-
-
-class TimespecParam(StructParamBase):
-    """Parameter decoder for struct timespec."""
-
-    struct_type = TimespecStruct
-    excluded_fields: ClassVar[set[str]] = set()
-    field_formatters: ClassVar[dict[str, str]] = {}
-
-    def __init__(self) -> None:
-        """Initialize TimespecParam."""
-        self.direction = ParamDirection.IN
-
-
-class TimevalStruct(ctypes.Structure):
-    """ctypes definition for struct timeval.
-
-    struct timeval {
-        time_t       tv_sec;   // seconds
-        suseconds_t  tv_usec;  // microseconds
-    };
-    """
-
-    _fields_: ClassVar[list[tuple[str, type]]] = [
-        ("tv_sec", ctypes.c_int64),  # time_t
-        ("tv_usec", ctypes.c_int32),  # suseconds_t (int32 on macOS)
-    ]
-
-
-class TimevalParam(StructParamBase):
-    """Parameter decoder for struct timeval."""
-
-    struct_type = TimevalStruct
-    excluded_fields: ClassVar[set[str]] = set()
-    field_formatters: ClassVar[dict[str, str]] = {}
-
-    def __init__(self) -> None:
-        """Initialize TimevalParam."""
-        self.direction = ParamDirection.IN
-
-
 @dataclass
 class FdSetParam(Param):
     """Parameter decoder for fd_set (file descriptor set).
@@ -547,6 +493,4 @@ __all__ = [
     "Kevent64Param",
     "KeventParam",
     "PollfdParam",
-    "TimespecParam",
-    "TimevalParam",
 ]

--- a/strace_macos/syscalls/struct_params/event_structs.py
+++ b/strace_macos/syscalls/struct_params/event_structs.py
@@ -12,7 +12,6 @@ from strace_macos.syscalls.definitions import (
     DecodeContext,
     Param,
     ParamDirection,
-    StructParamBase,
     SyscallArg,
 )
 from strace_macos.syscalls.symbols.ipc import POLL_EVENTS

--- a/strace_macos/syscalls/struct_params/time_structs.py
+++ b/strace_macos/syscalls/struct_params/time_structs.py
@@ -8,10 +8,15 @@ from typing import ClassVar
 from dataclasses import dataclass
 
 from strace_macos.syscalls.definitions import (
+    PointerArg,
     Param,
     ParamDirection,
     StructParamBase,
 )
+
+
+from strace_macos.syscalls.args import StructArrayArg
+from strace_macos.syscalls.struct_params.decode_array import decode_array
 
 
 class TimespecStruct(ctypes.Structure):
@@ -67,6 +72,7 @@ class TimevalParam(StructParamBase):
         """Initialize TimevalParam."""
         self.direction = direction
 
+
 class TimezoneStruct(ctypes.Structure):
     """
     struct timezone {
@@ -92,23 +98,30 @@ class TimezoneParam(StructParamBase):
         """Initialize TimezoneParam."""
         self.direction = direction
 
+
 @dataclass
-class TimevalArrayParam(Param):
-    """Parameter decoder for struct timeval array, used in utimes() / futimes() .
-    """
+class TimevalArray2Param(Param):
+    """Parameter decoder for struct timeval[2], used in utimes() / futimes()."""
+
+    def __init__(self, direction: ParamDirection) -> None:
+        """Initialize TimevalArray2Param."""
+        self.direction = direction
 
     def decode(self, ctx: DecodeContext) -> SyscallArg | None:
-        if not ctx.at_entry:
-            return None
-
         if ctx.raw_value == 0:
             return PointerArg(0)
 
-        timeval_list = decode_array.decode_array(ctx.process, ctx.raw_value, 2)
+        timeval_list = decode_array(
+            ctx,
+            address=ctx.raw_value,
+            count=2,
+            param=TimevalParam(self.direction)
+        )
+
         if timeval_list:
             return StructArrayArg(timeval_list)
 
         return PointerArg(ctx.raw_value)
 
 
-__all__ = ["TimespecParam", "TimevalParam", "TimezoneParam"]
+__all__ = ["TimespecParam", "TimevalParam", "TimezoneParam", "TimevalArray2Param"]

--- a/strace_macos/syscalls/struct_params/time_structs.py
+++ b/strace_macos/syscalls/struct_params/time_structs.py
@@ -108,6 +108,11 @@ class TimevalArray2Param(Param):
         self.direction = direction
 
     def decode(self, ctx: DecodeContext) -> SyscallArg | None:
+        if self.direction == ParamDirection.IN and not ctx.at_entry:
+            return None
+        if self.direction == ParamDirection.OUT and ctx.at_entry:
+            return None
+
         if ctx.raw_value == 0:
             return PointerArg(0)
 

--- a/strace_macos/syscalls/struct_params/time_structs.py
+++ b/strace_macos/syscalls/struct_params/time_structs.py
@@ -1,0 +1,94 @@
+"""Struct parameter decoders for kqueue/kevent/select/poll structures."""
+
+from __future__ import annotations
+
+import ctypes
+from typing import ClassVar
+
+from strace_macos.syscalls.definitions import (
+    ParamDirection,
+    StructParamBase,
+)
+
+
+class TimespecStruct(ctypes.Structure):
+    """ctypes definition for struct timespec.
+
+    struct timespec {
+        time_t  tv_sec;   // seconds
+        long    tv_nsec;  // nanoseconds
+    };
+    """
+
+    _fields_: ClassVar[list[tuple[str, type]]] = [
+        ("tv_sec", ctypes.c_int64),  # time_t
+        ("tv_nsec", ctypes.c_long),  # long
+    ]
+
+
+class TimespecParam(StructParamBase):
+    """Parameter decoder for struct timespec."""
+
+    struct_type = TimespecStruct
+    excluded_fields: ClassVar[set[str]] = set()
+    field_formatters: ClassVar[dict[str, str]] = {}
+
+    def __init__(self, direction: ParamDirection) -> None:
+        """Initialize TimespecParam."""
+        self.direction = direction
+
+
+class TimevalStruct(ctypes.Structure):
+    """ctypes definition for struct timeval.
+
+    struct timeval {
+        time_t       tv_sec;   // seconds
+        suseconds_t  tv_usec;  // microseconds
+    };
+    """
+
+    _fields_: ClassVar[list[tuple[str, type]]] = [
+        ("tv_sec", ctypes.c_int64),  # time_t
+        ("tv_usec", ctypes.c_int32),  # suseconds_t (int32 on macOS)
+    ]
+
+
+class TimevalParam(StructParamBase):
+    """Parameter decoder for struct timeval."""
+
+    struct_type = TimevalStruct
+    excluded_fields: ClassVar[set[str]] = set()
+    field_formatters: ClassVar[dict[str, str]] = {}
+
+    def __init__(self) -> None:
+        """Initialize TimevalParam."""
+        self.direction = ParamDirection.IN
+
+
+class TimezoneStruct(ctypes.Structure):
+    """
+    struct timezone {
+            int     tz_minuteswest; /* of Greenwich */
+            int     tz_dsttime;     /* type of dst correction to apply */
+    };
+    """
+
+    _fields_: ClassVar[list[tuple[str, type]]] = [
+        ("tz_minuteswest", ctypes.c_int),  # tz_minuteswest
+        ("tz_dsttime", ctypes.c_int),  # tz_dsttime
+    ]
+
+
+class TimezoneParam(StructParamBase):
+    """Parameter decoder for struct timezone."""
+
+    struct_type = TimezoneStruct
+    excluded_fields: ClassVar[set[str]] = set()
+    field_formatters: ClassVar[dict[str, str]] = {}
+
+    def __init__(self, direction: ParamDirection) -> None:
+        """Initialize TimezoneParam."""
+        self.direction = direction
+
+
+__all__ = ["TimespecParam", "TimevalParam", "TimezoneParam"]

--- a/strace_macos/syscalls/struct_params/time_structs.py
+++ b/strace_macos/syscalls/struct_params/time_structs.py
@@ -18,6 +18,32 @@ from strace_macos.syscalls.definitions import (
 from strace_macos.syscalls.args import StructArrayArg
 from strace_macos.syscalls.struct_params.decode_array import decode_array
 
+class ITimerValStruct(ctypes.Structure):
+    """ctypes definition for struct itimerval.
+
+    struct itimerval {
+        struct  timeval it_interval;    /* timer interval */
+        struct  timeval it_value;       /* current value */
+    };
+    """
+
+    _fields_: ClassVar[list[tuple[str, type]]] = [
+        ("tv_sec", ctypes.c_int64),  # time_t
+        ("tv_usec", ctypes.c_int32),  # suseconds_t (int32 on macOS)
+    ]
+
+
+class ITimerValParam(StructParamBase):
+    """Parameter decoder for struct itimerval."""
+
+    struct_type = ITimerValStruct
+    excluded_fields: ClassVar[set[str]] = set()
+    field_formatters: ClassVar[dict[str, str]] = {}
+
+    def __init__(self, direction: ParamDirection) -> None:
+        """Initialize ITimervalParam."""
+        self.direction = direction
+
 
 class TimespecStruct(ctypes.Structure):
     """ctypes definition for struct timespec.
@@ -129,4 +155,4 @@ class TimevalArray2Param(Param):
         return PointerArg(ctx.raw_value)
 
 
-__all__ = ["TimespecParam", "TimevalParam", "TimezoneParam", "TimevalArray2Param"]
+__all__ = ["ITimerValParam", "TimespecParam", "TimevalParam", "TimezoneParam", "TimevalArray2Param"]

--- a/strace_macos/syscalls/struct_params/time_structs.py
+++ b/strace_macos/syscalls/struct_params/time_structs.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import ctypes
 from typing import ClassVar
 
+from dataclasses import dataclass
+
 from strace_macos.syscalls.definitions import (
+    Param,
     ParamDirection,
     StructParamBase,
 )
@@ -60,10 +63,9 @@ class TimevalParam(StructParamBase):
     excluded_fields: ClassVar[set[str]] = set()
     field_formatters: ClassVar[dict[str, str]] = {}
 
-    def __init__(self) -> None:
+    def __init__(self, direction: ParamDirection) -> None:
         """Initialize TimevalParam."""
-        self.direction = ParamDirection.IN
-
+        self.direction = direction
 
 class TimezoneStruct(ctypes.Structure):
     """
@@ -89,6 +91,24 @@ class TimezoneParam(StructParamBase):
     def __init__(self, direction: ParamDirection) -> None:
         """Initialize TimezoneParam."""
         self.direction = direction
+
+@dataclass
+class TimevalArrayParam(Param):
+    """Parameter decoder for struct timeval array, used in utimes() / futimes() .
+    """
+
+    def decode(self, ctx: DecodeContext) -> SyscallArg | None:
+        if not ctx.at_entry:
+            return None
+
+        if ctx.raw_value == 0:
+            return PointerArg(0)
+
+        timeval_list = decode_array.decode_array(ctx.process, ctx.raw_value, 2)
+        if timeval_list:
+            return StructArrayArg(timeval_list)
+
+        return PointerArg(ctx.raw_value)
 
 
 __all__ = ["TimespecParam", "TimevalParam", "TimezoneParam"]

--- a/tests/fixtures/mode_time.h
+++ b/tests/fixtures/mode_time.h
@@ -27,6 +27,13 @@ int mode_time(int argc, char *argv[]) {
       settimeofday(&tv, &tz);
   }
 
+  /* === utimes() === */
+  {
+      struct timeval tv[2];
+      utimes("somefile", tv);
+  }
+
+  printf("DPNE\n");
   return 0;
 }
 

--- a/tests/fixtures/mode_time.h
+++ b/tests/fixtures/mode_time.h
@@ -8,10 +8,21 @@
 
 #include <stdio.h>
 #include <sys/time.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
 
 int mode_time(int argc, char *argv[]) {
   (void)argc; /* Unused parameter */
   (void)argv; /* Unused parameter */
+
+  // we don't actually want to run if this is launched as root; 
+  // we want the settimeofday/adjtime calls to fail, rather than
+  // actually set the time
+  if (getuid() == 0) {
+      fprintf(stderr, "cowardly refusing to run as root\n");
+      return -1;
+  }
 
   /* === gettimeofday() - get date and time === */
   {
@@ -27,13 +38,32 @@ int mode_time(int argc, char *argv[]) {
       settimeofday(&tv, &tz);
   }
 
+  const char* tempfile = "/tmp/strace_futimes_test.txt";
+  /* === futimes() === */
+  {
+      int fd = open(tempfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+      if (fd < 0) {
+          fprintf(stderr, "couldn't create tempfile for time tests\n");
+      }
+
+      struct timeval tv[2];
+      futimes(fd, tv);
+      close(fd);
+  }
+
   /* === utimes() === */
   {
       struct timeval tv[2];
-      utimes("somefile", tv);
+      utimes(tempfile, tv);
   }
 
-  printf("DPNE\n");
+  /* === adjtime === */
+  {
+      struct timeval delta = {1, 2};
+      struct timeval olddelta = {0, 0};
+      adjtime(&delta, &olddelta);
+  }
+  
   return 0;
 }
 

--- a/tests/fixtures/mode_time.h
+++ b/tests/fixtures/mode_time.h
@@ -45,6 +45,7 @@ int mode_time(int argc, char *argv[]) {
       int fd = open(tempfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
       if (fd < 0) {
           fprintf(stderr, "couldn't create tempfile for time tests\n");
+          return -1;
       }
 
       struct timeval tv[2] = {{999, 888}, {777, 666}};
@@ -60,14 +61,28 @@ int mode_time(int argc, char *argv[]) {
 
   unlink(tempfile);
 
-  /* === adjtime === */
+  /* === adjtime() === */
   {
       struct timeval delta = {1, 2};
       struct timeval olddelta = {0, 0};
       adjtime(&delta, &olddelta);
   }
   
+  /* === getitimer() === */
+  {
+      struct itimerval itv;
+      getitimer(ITIMER_VIRTUAL, &itv);
+  }
+
+  /* === setitimer() === */
+  {
+      struct itimerval value = {{1,2}, {0,0}};
+      struct itimerval ovalue;
+      setitimer(ITIMER_VIRTUAL, &value, &ovalue);
+  }
+
   return 0;
 }
 
 #endif /* MODE_TIME_H */
+

--- a/tests/fixtures/mode_time.h
+++ b/tests/fixtures/mode_time.h
@@ -39,6 +39,7 @@ int mode_time(int argc, char *argv[]) {
   }
 
   const char* tempfile = "/tmp/strace_futimes_test.txt";
+
   /* === futimes() === */
   {
       int fd = open(tempfile, O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -46,16 +47,18 @@ int mode_time(int argc, char *argv[]) {
           fprintf(stderr, "couldn't create tempfile for time tests\n");
       }
 
-      struct timeval tv[2];
+      struct timeval tv[2] = {{999, 888}, {777, 666}};
       futimes(fd, tv);
       close(fd);
   }
 
   /* === utimes() === */
   {
-      struct timeval tv[2];
+      struct timeval tv[2] = {{123, 456}, {654, 321}};
       utimes(tempfile, tv);
   }
+
+  unlink(tempfile);
 
   /* === adjtime === */
   {

--- a/tests/fixtures/mode_time.h
+++ b/tests/fixtures/mode_time.h
@@ -1,0 +1,33 @@
+/*
+ * time syscalls mode
+ * Tests: gettimeofday
+ */
+
+#ifndef MODE_TIME_H
+#define MODE_TIME_H
+
+#include <stdio.h>
+#include <sys/time.h>
+
+int mode_time(int argc, char *argv[]) {
+  (void)argc; /* Unused parameter */
+  (void)argv; /* Unused parameter */
+
+  /* === gettimeofday() - get date and time === */
+  {
+      struct timeval tv;
+      struct timezone tz;
+      gettimeofday(&tv, &tz);
+  }
+
+  /* === settimeofday() - set date and time === */
+  {
+      struct timeval tv = {100, 200};
+      struct timezone tz = {-60, 1};
+      settimeofday(&tv, &tz);
+  }
+
+  return 0;
+}
+
+#endif /* MODE_TIME_H */

--- a/tests/fixtures/modes.h
+++ b/tests/fixtures/modes.h
@@ -31,6 +31,7 @@ int mode_signal(int argc, char *argv[]);
 int mode_kqueue_select(int argc, char *argv[]);
 int mode_fork_exec(int argc, char *argv[]);
 int mode_sysinfo(int argc, char *argv[]);
+int mode_time(int argc, char *argv[]);
 int mode_long_running(int argc, char *argv[]);
 int mode_fail(int argc, char *argv[]);
 int mode_default(int argc, char *argv[]);
@@ -66,6 +67,8 @@ static const test_mode_t modes[] = {
      "Fork/exec ops (fork/vfork/execve/posix_spawn)"},
     {"--sysinfo", mode_sysinfo,
      "System info ops (sysctl/sysctlbyname/getdtablesize/gethostuuid/getentropy)"},
+    {"--time", mode_time,
+        "Time ops (setitimer/getitimer/gettimeofday/settimeofday/utimes/futimes/adjtime)"},
     {"--long-running", mode_long_running,
      "Long-running process for attach testing"},
     {"--fail", mode_fail, "Exit with non-zero status"},

--- a/tests/fixtures/test_executable.c
+++ b/tests/fixtures/test_executable.c
@@ -17,6 +17,7 @@
 #include "mode_process_advanced.h"
 #include "mode_signal.h"
 #include "mode_sysinfo.h"
+#include "mode_time.h"
 #include "modes.h"
 #include <string.h>
 

--- a/tests/test_time_syscalls.py
+++ b/tests/test_time_syscalls.py
@@ -30,8 +30,12 @@ class TestTimeSyscalls(unittest.TestCase):
         expected_syscalls = {
             "gettimeofday",
             "settimeofday",
+            "utimes",
+            "futimes",
+            "getitimer",
+            "setitimer",
         }
-        sth.assert_syscall_coverage(self.syscalls, expected_syscalls, 2, "time syscalls")
+        sth.assert_syscall_coverage(self.syscalls, expected_syscalls, 5, "time syscalls")
 
     def test_gettimeofday(self) -> None:
         """Test gettimeofday syscall parameter decodes."""
@@ -55,6 +59,30 @@ class TestTimeSyscalls(unittest.TestCase):
         assert "tz_minuteswest" in output, "missing tz_minuteswest field in output"
         assert "tz_dsttime" in output, "missing tz_dsttime field in output"
 
+    def _test_utimes(self) -> None:
+        """Test utimes syscall parameter decodes."""
+        print(self.syscalls)
+        utimes_calls = sth.filter_syscalls(self.syscalls, "utimes")
+        sth.assert_min_call_count(utimes_calls, 1, "utimes")
+
+        print(utimes_calls)
+        output = str(utimes_calls)
+        assert "tv_sec" in output, "missing tv_sec field in output"
+        assert "tv_usec" in output, "missing tv_usec field in output"
+
+    def _test_futimes(self) -> None:
+        """Test futimes syscall parameter decodes."""
+        print(self.syscalls)
+        futimes_calls = sth.filter_syscalls(self.syscalls, "futimes")
+        sth.assert_min_call_count(futimes_calls, 1, "futimes")
+
+    def _test_getitimer(self) -> None:
+        """Test getitimer syscall parameter decodes."""
+        print(self.syscalls)
+        getitimer_calls = sth.filter_syscalls(self.syscalls, "getitimer")
+        sth.assert_min_call_count(getitimer_calls, 1, "getitimer")
+
+        print(getitimer_calls)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_time_syscalls.py
+++ b/tests/test_time_syscalls.py
@@ -1,0 +1,60 @@
+"""Tests for time syscalls."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "fixtures"))
+import syscall_test_helpers as sth  # type: ignore[import-not-found]
+
+
+class TestTimeSyscalls(unittest.TestCase):
+    """Test time syscall decoding."""
+
+    exit_code: int
+    syscalls: list[dict]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Run the test executable once and capture syscalls for all tests."""
+        cls.exit_code, cls.syscalls = sth.run_strace_for_mode("--time", Path(__file__))
+
+    def test_executable_exits_successfully(self) -> None:
+        """Test that the executable runs without errors."""
+        assert self.exit_code == 0, f"Test executable should exit with 0, got {self.exit_code}"
+
+    def test_time_coverage(self) -> None:
+        """Test that expected time syscalls are captured."""
+        expected_syscalls = {
+            "gettimeofday",
+            "settimeofday",
+        }
+        sth.assert_syscall_coverage(self.syscalls, expected_syscalls, 2, "time syscalls")
+
+    def test_gettimeofday(self) -> None:
+        """Test gettimeofday syscall parameter decodes."""
+        gettimeofday_calls = sth.filter_syscalls(self.syscalls, "gettimeofday")
+        sth.assert_min_call_count(gettimeofday_calls, 1, "gettimeofday")
+
+        output = str(gettimeofday_calls)
+        assert "tv_sec" in output, "missing tv_sec field in output"
+        assert "tv_nsec" in output, "missing tv_nec field in output"
+        assert "tz_minuteswest" in output, "missing tz_minuteswest field in output"
+        assert "tz_dsttime" in output, "missing tz_dsttime field in output"
+
+    def test_settimeofday(self) -> None:
+        """Test settimeofday syscall parameter decodes."""
+        settimeofday_calls = sth.filter_syscalls(self.syscalls, "settimeofday")
+        sth.assert_min_call_count(settimeofday_calls, 1, "settimeofday")
+
+        output = str(settimeofday_calls)
+        assert "tv_sec" in output, "missing tv_sec field in output"
+        assert "tv_nsec" in output, "missing tv_nec field in output"
+        assert "tz_minuteswest" in output, "missing tz_minuteswest field in output"
+        assert "tz_dsttime" in output, "missing tz_dsttime field in output"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add support to decode struct timezone, and move existing time structs to their own file.
- Support decoding struct timeval as an OUT param.
- gettimeofday() and settimeofday() now use these structs when decoding.
