### PR TITLE
Set breakpoints in libsystem_kernel.

### DIFF
--- a/strace_macos/syscalls/args.py
+++ b/strace_macos/syscalls/args.py
@@ -31,7 +31,7 @@ class IntArg(SyscallArg):
 
     def __str__(self) -> str:
         """Return string representation."""
-        return self.symbolic if self.symbolic else str(self.value)
+        return self.symbolic or str(self.value)
 
 
 class UnsignedArg(SyscallArg):
@@ -115,7 +115,7 @@ class FlagsArg(SyscallArg):
 
     def __str__(self) -> str:
         """Return string representation."""
-        return self.symbolic if self.symbolic else f"0x{self.value:x}"
+        return self.symbolic or f"0x{self.value:x}"
 
 
 class StructArg(SyscallArg):

--- a/strace_macos/syscalls/formatters.py
+++ b/strace_macos/syscalls/formatters.py
@@ -41,7 +41,7 @@ class SyscallEvent:
 
 def _format_symbolic_or_value(arg: IntArg | FlagsArg) -> str | int:
     """Format IntArg or FlagsArg: prefer symbolic name if available, else value."""
-    return arg.symbolic if arg.symbolic else arg.value
+    return arg.symbolic or arg.value
 
 
 class JSONFormatter:

--- a/strace_macos/syscalls/struct_params/aiocb_array.py
+++ b/strace_macos/syscalls/struct_params/aiocb_array.py
@@ -118,7 +118,7 @@ class AiocbArrayParam(Param):
             except (ValueError, TypeError):
                 summaries.append("?")
 
-        return summaries if summaries else None
+        return summaries or None
 
     def _read_aiocb(self, process: Any, address: int) -> str | None:
         """Read and format a single aiocb structure.

--- a/strace_macos/syscalls/struct_params/event_structs.py
+++ b/strace_macos/syscalls/struct_params/event_structs.py
@@ -149,7 +149,7 @@ class KeventParam(Param):
 
             kevent_list.append(entry)
 
-        return kevent_list if kevent_list else None
+        return kevent_list or None
 
 
 def decode_kevent_filter(value: int) -> str:
@@ -332,7 +332,7 @@ class Kevent64Param(Param):
 
             kevent_list.append(entry)
 
-        return kevent_list if kevent_list else None
+        return kevent_list or None
 
 
 class PollfdStruct(ctypes.Structure):
@@ -420,7 +420,7 @@ class PollfdParam(Param):
                 }
             )
 
-        return pollfd_list if pollfd_list else None
+        return pollfd_list or None
 
     @staticmethod
     def _decode_events(value: int) -> str:

--- a/strace_macos/syscalls/struct_params/iovec.py
+++ b/strace_macos/syscalls/struct_params/iovec.py
@@ -109,7 +109,7 @@ class IovecParam(Param):
             buf_str = self._read_iovec_buffer(process, iov.iov_base, iov.iov_len)
             iov_list.append({"iov_base": buf_str, "iov_len": iov.iov_len})
 
-        return iov_list if iov_list else None
+        return iov_list or None
 
     @staticmethod
     def _read_iovec_buffer(process: Any, address: int, size: int) -> str:

--- a/strace_macos/syscalls/struct_params/msghdr.py
+++ b/strace_macos/syscalls/struct_params/msghdr.py
@@ -148,7 +148,7 @@ class MsghdrParam(StructParamBase):
             buf_str = self._read_iovec_buffer(process, iov.iov_base, iov.iov_len)
             iov_list.append({"iov_base": buf_str, "iov_len": iov.iov_len})
 
-        return iov_list if iov_list else None
+        return iov_list or None
 
     def _read_iovec_buffer(self, process: lldb.SBProcess, address: int, size: int) -> str:
         """Read and format an iovec buffer.

--- a/strace_macos/syscalls/struct_params/termios.py
+++ b/strace_macos/syscalls/struct_params/termios.py
@@ -135,7 +135,7 @@ class TermiosParam(StructParamBase):
             if lflag_names:
                 result["c_lflag"] = "|".join(lflag_names)
 
-        return result if result else {"c_iflag": "0"}
+        return result or {"c_iflag": "0"}
 
     def decode_struct(
         self, process: Any, address: int, *, no_abbrev: bool = False

--- a/strace_macos/tracer.py
+++ b/strace_macos/tracer.py
@@ -361,11 +361,27 @@ class Tracer:
         Args:
             target: LLDB target
         """
-        # Set breakpoints on all syscalls registered in the registry
-        # We use plain function names (no underscores) which are the libc wrappers
-        # that all programs call, regardless of compilation flags
+        # Limit search to the libsystem dylibs containing syscall wrappers;
+        # scanning all loaded modules is slow.
+        module_list = self.lldb.SBFileSpecList()
+        for dylib in (
+            "libsystem_kernel.dylib",
+            "libsystem_c.dylib",
+            "libsystem_pthread.dylib",
+            "libsystem_malloc.dylib",
+            "libsystem_platform.dylib",
+            "libsystem_info.dylib",
+            "libcopyfile.dylib",
+        ):
+            module_list.Append(self.lldb.SBFileSpec(dylib))
+        comp_unit_list = self.lldb.SBFileSpecList()
         for syscall_def in self.registry.get_all_syscalls():
-            target.BreakpointCreateByName(syscall_def.name, "libsystem_kernel.dylib")
+            target.BreakpointCreateByName(
+                syscall_def.name,
+                self.lldb.eFunctionNameTypeFull,
+                module_list,
+                comp_unit_list,
+            )
 
     def _trace_loop(self, process: lldb.SBProcess) -> int:
         """Main tracing loop.

--- a/strace_macos/tracer.py
+++ b/strace_macos/tracer.py
@@ -365,7 +365,7 @@ class Tracer:
         # We use plain function names (no underscores) which are the libc wrappers
         # that all programs call, regardless of compilation flags
         for syscall_def in self.registry.get_all_syscalls():
-            target.BreakpointCreateByName(syscall_def.name)
+            target.BreakpointCreateByName(syscall_def.name, "libsystem_kernel.dylib")
 
     def _trace_loop(self, process: lldb.SBProcess) -> int:
         """Main tracing loop.


### PR DESCRIPTION
Explicitly specify the "libsystem_kernel.dylib" module when setting breakpoints.  Without this, setting breakpoints by name for each syscall will end up creating a breakpoint for any method with the same name as the syscall, which can be pretty common.

For example, in a C++ program I was testing, the runtimes were:
no strace - 0.1 seconds
strace with this patch - 20 seconds
strace without this patch - 250 seconds

This was because there were thousands of calls to a method named `link()`, which was not the `link(2)` syscall.