### PR TITLE
fix(tracer): implement BSD-style errno decoding

### DIFF
--- a/strace_macos/syscalls/symbols/errno.py
+++ b/strace_macos/syscalls/symbols/errno.py
@@ -126,11 +126,22 @@ def decode_errno(value: int) -> str:
     Returns:
         Symbolic representation like "-1 ENOENT (No such file or directory)"
         or just the numeric value if not an error or unknown errno
+
+    Note:
+        On macOS, libc wrappers return -1 on error and set errno in thread-local storage.
+
+    Ref:
+        https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/syscall.2.html
     """
     if value >= 0:
         return str(value)
 
-    # Negative values are errors - negate to get errno number
+    # On macOS, syscalls return -1 on error (not -errno like Linux)
+    if value == -1:
+        return "-1"
+
+    # If we see other negative values (shouldn't happen on macOS libc wrappers,
+    # but might occur if tracing kernel directly), try to decode as errno
     errno_num = -value
     if errno_num in ERRNO_MAP:
         name, desc = ERRNO_MAP[errno_num]

--- a/strace_macos/tracer.py
+++ b/strace_macos/tracer.py
@@ -546,8 +546,19 @@ class Tracer:
                     signed_ret, event.raw_args, no_abbrev=self.no_abbrev
                 )
             elif not self.no_abbrev and signed_ret < 0:
-                # Apply errno decoding if enabled and return is an error
-                event.return_value = decode_errno(signed_ret)
+                # On macOS, syscalls return -1 on error
+                # Try to read errno from TLS
+                if signed_ret == -1:
+                    errno_value = self._read_errno(frame)
+                    if errno_value is not None:
+                        # Decode as -errno for the decoder
+                        event.return_value = decode_errno(-errno_value)
+                    else:
+                        # Fallback if _read_errno can't get it from TLS
+                        event.return_value = "?"
+                else:
+                    # Apply errno decoding if enabled and return is an error
+                    event.return_value = decode_errno(signed_ret)
             else:
                 event.return_value = signed_ret
         else:
@@ -562,6 +573,58 @@ class Tracer:
 
         # Write the complete event
         self._write_event(event)
+
+    def _read_errno(self, frame: lldb.SBFrame) -> int | None:
+        """Read errno value from thread-local storage via __error().
+
+        On macOS, errno is stored in thread-local storage. The __error() function
+        returns a pointer to the current thread's errno variable.
+
+        Args:
+            frame: LLDB stack frame at syscall return
+
+        Returns:
+            errno value, or None if reading failed
+        """
+        try:
+            # Create expression options
+            options = self.lldb.SBExpressionOptions()
+
+            options.SetTrapExceptions(False)  # noqa: FBT003
+            options.SetUnwindOnError(False)  # noqa: FBT003
+            options.SetIgnoreBreakpoints(True)  # noqa: FBT003
+            options.SetTimeoutInMicroSeconds(100000)  # 100ms timeout
+
+            # Try multiple ways to read errno
+            # First try the errno macro directly (most reliable)
+            errno_expr = frame.EvaluateExpression("errno", options)
+
+            # If that fails, try __error()
+            if not errno_expr.IsValid() or errno_expr.GetError().Fail():
+                errno_expr = frame.EvaluateExpression("*__error()", options)
+
+            # Check if evaluation succeeded
+            if not errno_expr.IsValid():
+                return None
+
+            error = errno_expr.GetError()
+            if error.Fail():
+                return None
+
+            # Get the errno value
+            errno_value = errno_expr.GetValueAsUnsigned()
+
+            # Sanity check: errno should be in valid range (1-107 on macOS)
+            #
+            # Ref: https://github.com/apple-oss-distributions/xnu/blob/main/bsd/sys/errno.h#L270
+            if errno_value > 0 and errno_value <= 107:
+                return int(errno_value)
+
+            return None  # noqa: TRY300
+
+        except Exception:  # noqa: BLE001
+            # If anything goes wrong, fail gracefully
+            return None
 
     def _extract_args(
         self, frame: lldb.SBFrame, syscall_name: str

--- a/strace_macos/tracer.py
+++ b/strace_macos/tracer.py
@@ -528,44 +528,10 @@ class Tracer:
         if not event:
             return
 
-        # Extract return value from return register
-        ret_reg = frame.FindRegister(self.arch.return_register)
-        if ret_reg and ret_reg.IsValid():
-            ret_value = ret_reg.GetValueAsUnsigned()
-            # Convert to signed if negative (syscalls return -errno on error)
-            if ret_value >= 0x8000000000000000:  # Sign bit set
-                signed_ret = int(ret_value) - 0x10000000000000000
-            else:
-                signed_ret = int(ret_value)
-
-            # Check if syscall has a custom return decoder
-            syscall_def = self.registry.lookup_by_name(event.syscall_name)
-            if syscall_def and syscall_def.return_decoder and signed_ret >= 0:
-                # Use custom return decoder
-                event.return_value = syscall_def.return_decoder(
-                    signed_ret, event.raw_args, no_abbrev=self.no_abbrev
-                )
-            elif not self.no_abbrev and signed_ret < 0:
-                # On macOS, syscalls return -1 on error
-                # Try to read errno from TLS
-                if signed_ret == -1:
-                    errno_value = self._read_errno(frame)
-                    if errno_value is not None:
-                        # Decode as -errno for the decoder
-                        event.return_value = decode_errno(-errno_value)
-                    else:
-                        # Fallback if _read_errno can't get it from TLS
-                        event.return_value = "?"
-                else:
-                    # Apply errno decoding if enabled and return is an error
-                    event.return_value = decode_errno(signed_ret)
-            else:
-                event.return_value = signed_ret
-        else:
-            event.return_value = "?"
+        # Decode return value
+        event.return_value = self._decode_return_value(frame, event)
 
         # Decode output parameters if syscall succeeded
-        # Only decode output params if return value indicates success (>= 0)
         if isinstance(event.return_value, int) and event.return_value >= 0:
             syscall_def = self.registry.lookup_by_name(event.syscall_name)
             if syscall_def:
@@ -573,6 +539,62 @@ class Tracer:
 
         # Write the complete event
         self._write_event(event)
+
+    def _decode_return_value(
+        self, frame: lldb.SBFrame, event: SyscallEvent
+    ) -> str | int:
+        """Decode syscall return value from register.
+
+        Args:
+            frame: LLDB stack frame
+            event: Syscall event with syscall name and raw args
+
+        Returns:
+            Decoded return value (int or string like "?" or "-1 ENOENT")
+        """
+        ret_reg = frame.FindRegister(self.arch.return_register)
+        if not ret_reg or not ret_reg.IsValid():
+            return "?"
+
+        # Convert to signed
+        ret_value = ret_reg.GetValueAsUnsigned()
+        signed_ret = (
+            int(ret_value) - 0x10000000000000000
+            if ret_value >= 0x8000000000000000
+            else int(ret_value)
+        )
+
+        # Check if syscall has a custom return decoder
+        syscall_def = self.registry.lookup_by_name(event.syscall_name)
+        if syscall_def and syscall_def.return_decoder and signed_ret >= 0:
+            return syscall_def.return_decoder(
+                signed_ret, event.raw_args, no_abbrev=self.no_abbrev
+            )
+
+        # Handle error returns
+        if not self.no_abbrev and signed_ret < 0:
+            return self._decode_error_return(frame, signed_ret)
+
+        return signed_ret
+
+    def _decode_error_return(self, frame: lldb.SBFrame, signed_ret: int) -> str | int:
+        """Decode error return value (macOS -1 with errno in TLS).
+
+        Args:
+            frame: LLDB stack frame
+            signed_ret: Signed return value (negative)
+
+        Returns:
+            Decoded error string like "-1 ENOENT" or "?" on failure
+        """
+        if signed_ret == -1:
+            errno_value = self._read_errno(frame)
+            if errno_value is not None:
+                return decode_errno(-errno_value)
+            return "?"
+
+        # Other negative values (shouldn't happen on macOS libc wrappers)
+        return decode_errno(signed_ret)
 
     def _read_errno(self, frame: lldb.SBFrame) -> int | None:
         """Read errno value from thread-local storage via __error().

--- a/tests/fixtures/mode_errno_test.h
+++ b/tests/fixtures/mode_errno_test.h
@@ -1,0 +1,53 @@
+/*
+ * Errno test mode - generates syscalls that fail with various errors
+ */
+
+#ifndef MODE_ERRNO_TEST_H
+#define MODE_ERRNO_TEST_H
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int mode_errno_test(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  /* Try to open non-existent file - will fail with ENOENT */
+  int fd = open("/tmp/this_file_definitely_does_not_exist_12345.txt", O_RDONLY);
+  if (fd == -1) {
+    /* Expected to fail */
+  }
+
+  /* Try to read from invalid fd - will fail with EBADF */
+  char buf[10];
+  ssize_t ret = read(999, buf, sizeof(buf));
+  if (ret == -1) {
+    /* Expected to fail */
+  }
+
+  /* Try to write to invalid fd - will fail with EBADF */
+  ret = write(999, "test", 4);
+  if (ret == -1) {
+    /* Expected to fail */
+  }
+
+  /* Try to stat non-existent file - will fail with ENOENT */
+  struct stat st;
+  int stat_ret = stat("/tmp/nonexistent_file_54321.txt", &st);
+  if (stat_ret == -1) {
+    /* Expected to fail */
+  }
+
+  /* Try to access non-existent file - will fail with ENOENT */
+  int access_ret = access("/tmp/another_nonexistent_file_99999.txt", R_OK);
+  if (access_ret == -1) {
+    /* Expected to fail */
+  }
+
+  return 0;
+}
+
+#endif /* MODE_ERRNO_TEST_H */

--- a/tests/fixtures/modes.h
+++ b/tests/fixtures/modes.h
@@ -33,6 +33,7 @@ int mode_fork_exec(int argc, char *argv[]);
 int mode_sysinfo(int argc, char *argv[]);
 int mode_long_running(int argc, char *argv[]);
 int mode_fail(int argc, char *argv[]);
+int mode_errno_test(int argc, char *argv[]);
 int mode_default(int argc, char *argv[]);
 
 /* Global mode registry */
@@ -69,6 +70,8 @@ static const test_mode_t modes[] = {
     {"--long-running", mode_long_running,
      "Long-running process for attach testing"},
     {"--fail", mode_fail, "Exit with non-zero status"},
+    {"--errno-test", mode_errno_test,
+     "Test errno return values (generates syscall failures)"},
     {NULL, mode_default, "Default mode: print args"},
 };
 

--- a/tests/fixtures/test_executable.c
+++ b/tests/fixtures/test_executable.c
@@ -17,6 +17,7 @@
 #include "mode_process_advanced.h"
 #include "mode_signal.h"
 #include "mode_sysinfo.h"
+#include "mode_errno_test.h"
 #include "modes.h"
 #include <string.h>
 

--- a/tests/test_symbolic_decoding.py
+++ b/tests/test_symbolic_decoding.py
@@ -190,6 +190,107 @@ class TestSymbolicDecoding(StraceTestCase):
             f"stat syscalls should include decoded st_mode. Found: {stat_calls}"
         )
 
+    def test_errno_return_value_formatting(self) -> None:
+        """Test that error returns show errno from TLS.
+
+        On macOS (BSD-style), syscalls return -1 on error and set errno in TLS.
+        The tracer should read errno and show the actual error (e.g., ENOENT, EBADF).
+        """
+        output_file = self.temp_dir / "trace.txt"
+
+        # Trace test executable with errno test mode
+        exit_code = main(
+            [
+                "-o",
+                str(output_file),
+                str(self.test_executable),
+                "--errno-test",
+            ]
+        )
+
+        assert exit_code == 0, "strace should exit with code 0"
+        content = output_file.read_text()
+
+        # Find syscalls that should have failed (return -1)
+        # Look for open, read, write, stat, access calls
+        failed_syscalls = [line for line in content.split("\n") if " = -1" in line]
+
+        assert len(failed_syscalls) > 0, f"Should find failed syscalls in output:\n{content}"
+
+        # With errno reading enabled by default, should see actual errno names
+        found_errno_decoding = False
+        errno_names = ["ENOENT", "EBADF", "EINVAL"]
+
+        for line in failed_syscalls:
+            for errno_name in errno_names:
+                if errno_name in line:
+                    found_errno_decoding = True
+                    break
+
+        assert found_errno_decoding, (
+            f"Should find errno names (ENOENT, EBADF, etc.) in failed syscalls. "
+            f"Failed syscalls: {failed_syscalls}"
+        )
+
+    def test_errno_return_value_formatting_json(self) -> None:
+        """Test that error returns show errno in JSON output."""
+        output_file = self.temp_dir / "trace.jsonl"
+
+        # Trace test executable with errno test mode and JSON output
+        exit_code = main(
+            [
+                "--json",
+                "-o",
+                str(output_file),
+                str(self.test_executable),
+                "--errno-test",
+            ]
+        )
+
+        assert exit_code == 0, "strace should exit with code 0"
+        syscalls = helpers.json_lines(output_file)
+        assert len(syscalls) > 0, "Should capture syscalls"
+
+        # Find syscalls that failed (return starts with -1)
+        failed_syscalls = [
+            sc
+            for sc in syscalls
+            if isinstance(sc.get("return"), str) and sc.get("return", "").startswith("-1")
+        ]
+
+        # Debug: print all return values for open/read/write/stat/access
+        debug_syscalls = [
+            (sc.get("syscall"), sc.get("return"))
+            for sc in syscalls
+            if sc.get("syscall") in ("open", "read", "write", "stat", "access")
+        ]
+
+        assert len(failed_syscalls) > 0, (
+            f"Should find failed syscalls in JSON output. "
+            f"Debug syscalls with returns: {debug_syscalls}"
+        )
+
+        # Verify that failed syscalls show errno
+        # and that errno is decoded from TLS
+        found_errno_decoding = False
+        errno_names = ["ENOENT", "EBADF", "EINVAL"]
+
+        for sc in failed_syscalls:
+            return_val = sc.get("return")
+            if not return_val:
+                continue
+
+            # Check for actual errno names
+            for errno_name in errno_names:
+                if errno_name in return_val:
+                    found_errno_decoding = True
+                    break
+
+        assert found_errno_decoding, (
+            f"Should find errno names (ENOENT, EBADF, etc.) in JSON return values. "
+            f"Failed syscalls: {[(sc.get('syscall'), sc.get('return')) for sc in failed_syscalls]}"
+        )
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
- read errno from thread-local storage via __error() instead of assuming Linux-style -errno returns
- add _read_errno() method to read errno via LLDB expression evaluation at syscall return
- update decode_errno() to handle macOS convention where syscalls return -1 on error
- add errno test fixture (mode_errno_test.h) that generates ENOENT and EBADF errors
- add tests for errno decoding in both text and JSON output formats

On macOS/BSD, libc wrappers return -1 on error and set errno in thread-local storage, unlike Linux where syscalls return -errno directly. This change properly reads errno from TLS using LLDB's expression evaluator with optimised options (no exception trapping, no unwinding, ignore breakpoints, 100ms timeout).

Fixes: #53

🤖 Generated with [Claude Code](https://claude.ai/code)

Issue: https://github.com/Mic92/strace-macos/issues/53